### PR TITLE
replace_missing, missing_if, @rename_with

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierData"
 uuid = "fe2206b3-d496-4ee9-a338-6a095c4ece80"
 authors = ["Karandeep Singh"]
-version = "0.12.2"
+version = "0.13.0"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ To support R-style programming, TidierData.jl is implemented using macros.
 TidierData.jl currently supports the following top-level macros:
 
 - `@glimpse()`
-- `@select()`, `@rename()`, and `@distinct()`
+- `@select()` and `@distinct()`
+- `@rename()` and `@rename_with()`
 - `@mutate()` and `@transmute()` 
 - `@summarize()` and `@summarise()`
 - `@filter()`
@@ -106,6 +107,7 @@ TidierData.jl also supports the following helper functions:
 - `everything()`, `starts_with()`, `ends_with()`, `matches()`, and `contains()`
 - `as_float()`, `as_integer()`, and `as_string()`
 - `is_float()`, `is_integer()`, and `is_string()`
+- `missing_if()` and `replace_missing()`
 
 See the documentation [Home](https://tidierorg.github.io/TidierData.jl/latest/) page for a guide on how to get started, or the [Reference](https://tidierorg.github.io/TidierData.jl/latest/reference/) page for a detailed guide to each of the macros and functions.
 

--- a/docs/examples/UserGuide/fill_missing.jl
+++ b/docs/examples/UserGuide/fill_missing.jl
@@ -34,3 +34,18 @@ end
     @fill_missing(a, "down")
 end
 
+# ## `replace_missing()`
+# The `replace_missing` function facilitates the replacement of `missing` values with a specified replacement. 
+
+@chain df begin
+    @mutate(b = replace_missing(b, 2))
+end 
+
+# ## `missing_if()`
+# The `missing_if` function is used to introduce `missing` values under specific conditions. 
+
+@chain df begin
+    @mutate(b = missing_if(b, 5))
+end 
+
+# Both `missing_if` and `replace_missing` are not type specifc.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -90,7 +90,8 @@ TidierData.jl currently supports the following top-level macros:
 ```@raw html
 !!! example "Top-level macros:"
     - `@glimpse()`
-    - `@select()`, `@rename()`, and `@distinct()`
+    - `@select()` and `@distinct()`
+    - `@rename()` and `@rename_with()`
     - `@mutate()` and `@transmute()` 
     - `@summarize()` and `@summarise()`
     - `@filter()`
@@ -120,6 +121,7 @@ TidierData.jl also supports the following helper functions:
     - `everything()`, `starts_with()`, `ends_with()`, `matches()`, and `contains()`
     - `as_float()`, `as_integer()`, and `as_string()`
     - `is_float()`, `is_integer()`, and `is_string()`
+    - `missing_if()` and `replace_missing()`
 ```
 
 See the [Reference](https://tidierorg.github.io/TidierData.jl/latest/reference/) page for a detailed guide to each of the macros and functions.

--- a/src/TidierData.jl
+++ b/src/TidierData.jl
@@ -19,7 +19,7 @@ export TidierData_set, across, desc, n, row_number, everything, starts_with, end
       as_float, as_integer, as_string, is_float, is_integer, is_string, missing_if, replace_missing, @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter,
       @group_by, @ungroup, @slice, @arrange, @distinct, @pull, @left_join, @right_join, @inner_join, @full_join,
       @pivot_wider, @pivot_longer, @bind_rows, @bind_cols, @clean_names, @count, @tally, @drop_missing, @glimpse, @separate,
-      @unite, @summary, @fill_missing, @slice_sample
+      @unite, @summary, @fill_missing, @slice_sample, @rename_with
 
 # Package global variables
 const code = Ref{Bool}(false) # output DataFrames.jl code?

--- a/src/TidierData.jl
+++ b/src/TidierData.jl
@@ -16,7 +16,7 @@ using Reexport
 @reexport using ShiftedArrays: lag, lead
 
 export TidierData_set, across, desc, n, row_number, everything, starts_with, ends_with, matches, if_else, case_when, ntile, 
-      as_float, as_integer, as_string, is_float, is_integer, is_string, @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter,
+      as_float, as_integer, as_string, is_float, is_integer, is_string, missing_if, replace_missing, @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter,
       @group_by, @ungroup, @slice, @arrange, @distinct, @pull, @left_join, @right_join, @inner_join, @full_join,
       @pivot_wider, @pivot_longer, @bind_rows, @bind_cols, @clean_names, @count, @tally, @drop_missing, @glimpse, @separate,
       @unite, @summary, @fill_missing, @slice_sample

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2454,7 +2454,7 @@ Replace a specific `value` with `missing` in `x`.
 
 ## Examples
 ```jldoctest
-julia> df = DataFrame(a = [1, missing, 3, 4], b = ["apple", "apple", "banana", "cherry"])
+julia> df = DataFrame(a = [1, missing, 3, 4], b = ["apple", "apple", "banana", "cherry"]);
 
 julia> @chain df begin
        @mutate(a = missing_if(a, 4), b = missing_if(b, "apple"))

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2441,3 +2441,59 @@ julia> @chain df begin
    5 │    25      5     15
 ```
 """
+
+const docstring_missing_if =
+"""
+    missing_if(x, value)
+
+Replace a specific `value` with `missing` in `x`.
+
+## Arguments
+- `x`: The input value which can be of any type. If `x` is already `missing` or equals `value`, the function will return `missing`. Otherwise, it returns `x` unaltered.
+- `value`: The specific value to be checked against. 
+
+## Examples
+```jldoctest
+julia> df = DataFrame(a = [1, missing, 3, 4], b = ["apple", "apple", "banana", "cherry"])
+
+julia> @chain df begin
+       @mutate(a = missing_if(a, 4), b = missing_if(b, "apple"))
+       end
+4×2 DataFrame
+ Row │ a        b       
+     │ Int64?   String? 
+─────┼──────────────────
+   1 │       1  missing 
+   2 │ missing  missing 
+   3 │       3  banana
+   4 │ missing  cherry
+```
+"""
+
+const docstring_replace_missing =
+"""
+    replace_missing(x, replacement)
+
+Replace `missing` values in `x` with a specified `replacement` value.
+
+# Arguments
+- `x`: The input value which can be of any type. If `x` is `missing`, the function will return `replacement`. Otherwise, it returns `x` unaltered.
+- `replacement`: The value to replace `missing` with in `x`.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a = [1, missing, 3, 4], b = [4, 5, missing, 8]);
+
+julia> @chain df begin
+       @mutate(a = replace_missing(a, 100), b = replace_missing(b, 35))
+       end
+4×2 DataFrame
+ Row │ a      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      4
+   2 │   100      5
+   3 │     3     35
+   4 │     4      8
+```
+"""

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2540,3 +2540,4 @@ julia> @rename_with(df, str -> str_remove_all(str, "_a"), !term_a)
    2 │ banana  doc2          2
    3 │ cherry  doc3          3
 ```
+"""

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2513,18 +2513,18 @@ a range of variables. Variables names can also be chosen with starts with. Defau
 
 # Examples
 ```jldoctest
-julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
-
 julia> function str_remove_all(column, pattern::String)
-    if ismissing(column)
-        return column
-    end
-    patterns = split(pattern, '|')
-    for p in patterns
-        column = replace(column, strip(p) => "")
-    end
-    return column
-end;
+         if ismissing(column)
+             return column
+         end
+         patterns = split(pattern, '|')
+         for p in patterns
+             column = replace(column, strip(p) => "")
+         end
+         return column
+       end;
+
+julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
 
 julia> @rename_with(df, str -> str_remove_all(str, "_a"), !term_a)
 10×3 DataFrame

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2499,7 +2499,6 @@ julia> @chain df begin
 """
 
 const docstring_rename_with =
-
 """
      @rename_with(df, fn, exprs...)
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2515,19 +2515,14 @@ a range of variables. Variables names can also be chosen with starts with. Defau
 ```jldoctest
 julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
 
-julia> function str_remove_all(column, pattern::Union{String, Regex})
+julia> function str_remove_all(column, pattern::String)
     if ismissing(column)
-        return(column)
-    end 
-    if pattern isa String
-        patterns = split(pattern, '|')
-        for p in patterns
-            column = replace(column, Regex(strip(p)) => "")
-        end
-    else
-        column = replace(column, pattern => "")
+        return column
     end
-    column = replace(column, r"\s+" => " ")
+    patterns = split(pattern, '|')
+    for p in patterns
+        column = replace(column, strip(p) => "")
+    end
     return column
 end;
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2497,3 +2497,47 @@ julia> @chain df begin
    4 │     4      8
 ```
 """
+
+const docstring_rename_with =
+
+"""
+     @rename_with(df, fn, exprs...)
+
+Renames the chosen column names with using a function
+
+# Arguments
+- `df`: a DataFrame
+- `fn`: desired function to (such as str_remove_all from TidierStrings)
+- `exprs`: One or more unquoted variable names separated by commas. Variable names 
+can also be used as their positions in the data, like `x:y`, to select 
+a range of variables. Variables names can also be chosen with starts with. Defaults to all columns if empty.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
+
+julia> function str_remove_all(column, pattern::Union{String, Regex})
+    if ismissing(column)
+        return(column)
+    end 
+    if pattern isa String
+        patterns = split(pattern, '|')
+        for p in patterns
+            column = replace(column, Regex(strip(p)) => "")
+        end
+    else
+        column = replace(column, pattern => "")
+    end
+    column = replace(column, r"\s+" => " ")
+    return column
+end;
+
+julia> @rename_with(df, str -> str_remove_all(str, "_a"), !term_a)
+10×3 DataFrame
+ Row │ term_a  document  _n_   
+     │ String  String    Int64 
+─────┼─────────────────────────
+   1 │ apple   doc_1         1
+   2 │ banana  doc2          2
+   3 │ cherry  doc3          3
+```

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2527,7 +2527,7 @@ julia> function str_remove_all(column, pattern::String)
 julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
 
 julia> @rename_with(df, str -> str_remove_all(str, "_a"), !term_a)
-10×3 DataFrame
+3×3 DataFrame
  Row │ term_a  document  _n_   
      │ String  String    Int64 
 ─────┼─────────────────────────

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2580,10 +2580,14 @@ Replace a specific `value` with `missing` in `x`.
 
 ## Examples
 ```jldoctest
-julia> df = DataFrame(a = [1, missing, 3, 4], b = ["apple", "apple", "banana", "cherry"]);
+julia> df = DataFrame(
+              a = [1, missing, 3, 4],
+              b = ["apple", "apple", "banana", "cherry"]
+            );
 
 julia> @chain df begin
-       @mutate(a = missing_if(a, 4), b = missing_if(b, "apple"))
+       @mutate(a = missing_if(a, 4), 
+               b = missing_if(b, "apple"))
        end
 4×2 DataFrame
  Row │ a        b       
@@ -2608,10 +2612,14 @@ Replace `missing` values in `x` with a specified `replacement` value.
 
 # Examples
 ```jldoctest
-julia> df = DataFrame(a = [1, missing, 3, 4], b = [4, 5, missing, 8]);
+julia> df = DataFrame(
+              a = [1, missing, 3, 4],
+              b = [4, 5, missing, 8]
+            );
 
 julia> @chain df begin
-       @mutate(a = replace_missing(a, 100), b = replace_missing(b, 35))
+       @mutate(a = replace_missing(a, 100),
+               b = replace_missing(b, 35))
        end
 4×2 DataFrame
  Row │ a      b     
@@ -2628,7 +2636,7 @@ const docstring_rename_with =
 """
      @rename_with(df, fn, exprs...)
 
-Renames the chosen column names with using a function
+Renames the chosen column names using a function
 
 # Arguments
 - `df`: a DataFrame
@@ -2650,7 +2658,11 @@ julia> function str_remove_all(column, pattern::String)
          return column
        end;
 
-julia> df = DataFrame(term_a = ["apple", "banana", "cherry"], document_a = ["doc_1", "doc2", "doc3"], _n_ = [1, 2, 3]); 
+julia> df = DataFrame(
+              term_a = ["apple", "banana", "cherry"],
+              document_a = ["doc_1", "doc2", "doc3"],
+              _n_ = [1, 2, 3]
+            ); 
 
 julia> @rename_with(df, str -> str_remove_all(str, "_a"), !term_a)
 3×3 DataFrame

--- a/src/missings.jl
+++ b/src/missings.jl
@@ -116,3 +116,13 @@ macro fill_missing(df, args...)
       end
   end
 end
+
+"""
+$docstring_missing_if
+"""
+missing_if(x, value) = ismissing(x) ? x : (x == value ? missing : x)
+
+"""
+$docstring_replace_missing
+"""
+replace_missing(x, replacement) = ismissing(x) ? replacement : x


### PR DESCRIPTION
-added replace_missing and missing_if
-added parse_interp to unite
-added rename_with macro

was not sure how to do the docstring because it relies on a TidierStrings, but all the following use cases work

@rename_with(df3, str -> str_replace_all(str, "_", "FF"))
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), 3)
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), !3)
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), !term_a)
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), 2:3)
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), ends_with("a"))
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), term_a)
@rename_with(df3, str -> str_replace_all(str, "_", "FF"), term_a:document_a)