### PR TITLE
Tidied fill missing macro

### DIFF
--- a/src/missings.jl
+++ b/src/missings.jl
@@ -42,44 +42,25 @@ end
 
 function fill_missing(df::DataFrame, columns, method::String)
   new_df = copy(df)
-  column_symbols = []
-    ### this section here allow it to handle : as a between identifier with columns, as well as negated numbers -3 for columns. 
+  column_symbols = from_parse_tidy(new_df, columns)
 
-    for col in columns
-      if col isa Integer
-          push!(column_symbols, Symbol(names(new_df)[col]))
-      elseif col isa AbstractRange
-          append!(column_symbols, Symbol.(names(new_df)[collect(col)]))
-      elseif typeof(col) <: Between
-          # Get the column indices for the Between range
-          col_indices = DataFrames.index(new_df)[col]
-          append!(column_symbols, Symbol.(names(new_df)[col_indices]))
-        elseif col isa InvertedIndex
-          # Handle InvertedIndex (negative indexing)
-          excluded_col = names(new_df)[col.skip]
-          append!(column_symbols, setdiff(names(new_df), [excluded_col]))
-      else
-          push!(column_symbols, Symbol(col))
-      end
-  end
-
-  for col_syl in column_symbols
+  for col_sym in column_symbols
       if method == "down"
-          last_observation = new_df[1, col_syl]
+          last_observation = new_df[1, col_sym]
           for i in 1:nrow(new_df)
-              if ismissing(new_df[i, col_syl])
-                  new_df[i, col_syl] = last_observation
+              if ismissing(new_df[i, col_sym])
+                  new_df[i, col_sym] = last_observation
               else
-                  last_observation = new_df[i, col_syl]
+                  last_observation = new_df[i, col_sym]
               end
           end
       elseif method == "up"
-          next_observation = new_df[end, col_syl]
+          next_observation = new_df[end, col_sym]
           for i in nrow(new_df):-1:1
-              if ismissing(new_df[i, col_syl])
-                  new_df[i, col_syl] = next_observation
+              if ismissing(new_df[i, col_sym])
+                  new_df[i, col_sym] = next_observation
               else
-                  next_observation = new_df[i, col_syl]
+                  next_observation = new_df[i, col_sym]
               end
           end
       else

--- a/src/separate_unite.jl
+++ b/src/separate_unite.jl
@@ -151,21 +151,8 @@ function separate_rows(df::Union{DataFrame, GroupedDataFrame}, columns, delimite
   temp_df = copy(is_grouped ? parent(df) : df)
    # temp_df = copy(df)
 
-  # Convert all references to column symbols
-  column_symbols = []
-  for col in columns
-      if col isa Integer
-          push!(column_symbols, Symbol(names(temp_df)[col]))
-      elseif col isa AbstractRange
-          append!(column_symbols, Symbol.(names(temp_df)[collect(col)]))
-      elseif typeof(col) <: Between
-          # Get the column indices for the Between range
-          col_indices = DataFrames.index(temp_df)[col]
-          append!(column_symbols, Symbol.(names(temp_df)[col_indices]))
-      else
-          push!(column_symbols, Symbol(col))
-      end
-  end
+  # parse what comes from parse_tidy enable negation, negated ranges, ranges etc.
+  column_symbols = from_parse_tidy(temp_df, columns)
 
   # Initialize an array to hold expanded data for each column
   expanded_data = Dict{Symbol, Vector{Any}}()


### PR DESCRIPTION
- added parse_interpolation and parse_tidy to @fill_missing. 

While working on this and separate_rows, I realized (i think) that functions  that leverage df.jl, but are not df.jl functions don't support all the selection methods that parse_tidy does (ie between, negation, and numbers).

I put together a from_parse_tidy function to better enable tidy selection in other functions. So now, for example, @fill_missing() supports the following (in addition to interpolation:

```
@fill_missing(df, dt1:dt2 ,dt4, "down")
@fill_missing(df, !1, "down")
@fill_missing(df, !(dt1:dt3), "down")
@fill_missing(df, !(3:4), "down")

@fill_missing(df, !a, "down") # this is the only one that continues to elude me.
```

it is definitely possible there is pre-existing, more elegant, or more efficient way to do this. But if not, perhaps this could be a temporary method or future TidierTool? Happy to nix it as well.

Edit: Perhaps a more appropriate name would have been `columns_from_parse_tidy()` ? 