### PR TITLE
Add tests for mutate

### DIFF
--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -537,10 +537,12 @@ Note that unlike dplyr, @mutate transformations cannot be applied progressively-
 julia> @chain df begin
         #=
         it's tempting to do this:
+
           @mutate begin
             b2 = b * 2
             b3 = b2 * 2
           end
+
         but this syntactic sugar isn't supported.
         use separate @mutate calls instead.
         =#

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -532,6 +532,22 @@ julia> @chain df begin
    4 │ d         4     14          1         11
    5 │ e         5     15          1         11
 ```
+Note that unlike dplyr, @mutate transformations cannot be applied progressively-meaning you cannot reuse variables within the same @mutate call. This requires the use of separate @mutate calls.
+```
+julia> @chain df begin
+          @mutate b2 = b * 2
+          @mutate b3 = b2 * 2
+        end
+5×5 DataFrame
+ Row │ a     b      c      b2     b3
+     │ Char  Int64  Int64  Int64  Int64
+─────┼──────────────────────────────────
+   1 │ a         1     11      2      4
+   2 │ b         2     12      4      8
+   3 │ c         3     13      6     12
+   4 │ d         4     14      8     16
+   5 │ e         5     15     10     20
+```
 """
 
 const docstring_summarize =

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -531,6 +531,21 @@ julia> @chain df begin
    3 │ c         3     13          1         11
    4 │ d         4     14          1         11
    5 │ e         5     15          1         11
+Note that unlike dplyr, @mutate transformations cannot be applied progressively-meaning you cannot reuse variables within the same @mutate call. This requires the use of separate @mutate calls.
+
+julia> @chain df begin
+          @mutate b2 = b * 2
+          @mutate b3 = b2 * 2
+        end
+5×5 DataFrame
+ Row │ a     b      c      b2     b3
+     │ Char  Int64  Int64  Int64  Int64
+─────┼──────────────────────────────────
+   1 │ a         1     11      2      4
+   2 │ b         2     12      4      8
+   3 │ c         3     13      6     12
+   4 │ d         4     14      8     16
+   5 │ e         5     15     10     20
 ```
 """
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -531,21 +531,6 @@ julia> @chain df begin
    3 │ c         3     13          1         11
    4 │ d         4     14          1         11
    5 │ e         5     15          1         11
-Note that unlike dplyr, @mutate transformations cannot be applied progressively-meaning you cannot reuse variables within the same @mutate call. This requires the use of separate @mutate calls.
-
-julia> @chain df begin
-          @mutate b2 = b * 2
-          @mutate b3 = b2 * 2
-        end
-5×5 DataFrame
- Row │ a     b      c      b2     b3
-     │ Char  Int64  Int64  Int64  Int64
-─────┼──────────────────────────────────
-   1 │ a         1     11      2      4
-   2 │ b         2     12      4      8
-   3 │ c         3     13      6     12
-   4 │ d         4     14      8     16
-   5 │ e         5     15     10     20
 ```
 """
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -535,6 +535,15 @@ julia> @chain df begin
 Note that unlike dplyr, @mutate transformations cannot be applied progressively-meaning you cannot reuse variables within the same @mutate call. This requires the use of separate @mutate calls.
 ```
 julia> @chain df begin
+        #=
+        it's tempting to do this:
+          @mutate begin
+            b2 = b * 2
+            b3 = b2 * 2
+          end
+        but this syntactic sugar isn't supported.
+        use separate @mutate calls instead.
+        =#
           @mutate b2 = b * 2
           @mutate b3 = b2 * 2
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ test_df = DataFrame(
 
 @testset "TidierData" verbose = true begin
     include("test_pivots.jl")
+    include("test_mutate.jl")
 end

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -88,15 +88,19 @@
         z = 1:5
 
         @test isequal(@mutate(df, y = !!y)[!, :y], y)
-        @test isequal(
-            (@chain df begin
-                @group_by(g)
-                @mutate y = !!y
-                @ungroup
-                @pull y
-            end
-            )
-        )
+        #=
+            i'm not actually sure whether this test would be one-to-one with Julia,
+            given that grouped dataframes behave differently than in R.
+        =#
+        # @test isequal(
+        #     (@chain df begin
+        #         @group_by(g)
+        #         @mutate y = !!y
+        #         @ungroup
+        #         @pull y
+        #     end
+        #     )
+        # )
     end
 
     @testset "mutate works on empty dataframes" begin

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -62,4 +62,23 @@
         @test_throws "ArgumentError: New columns must have the same length as old columns" @mutate(df, y = 1:2)
     end
 
+    @testset "can remove variables with nothing" begin
+        df = DataFrame(x = 1:3, y = 1:3)
+
+        @test isequal(@mutate(df, y = nothing), df[:, [1]])
+        @test isequal(@ungroup(@mutate(gf, y = nothing)), gf[:, [1]])
+
+        # even if it doesn't exist
+        @test isequal(@mutate(df, z = nothing), df[:, [1]])
+
+        # or was just created
+        @test isequal(
+            (@mutate df begin
+                z = 1,
+                z = nothing
+            end
+            ),
+            df
+        )
+    end
 end

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -18,26 +18,6 @@
         @test_throws "ArgumentError: New columns must have the same length as old columns" @mutate(df, y = 1:2)
     end
 
-    @testset "can remove variables with nothing" begin
-        df = DataFrame(x = 1:3, y = 1:3)
-
-        @test isequal(@mutate(df, y = nothing), df[:, [1]])
-        @test isequal(@ungroup(@mutate(gf, y = nothing)), gf[:, [1]])
-
-        # even if it doesn't exist
-        @test isequal(@mutate(df, z = nothing), df[:, [1]])
-
-        # or was just created
-        @test isequal(
-            (@mutate df begin
-                z = 1
-                z = nothing
-            end
-            ),
-            df
-        )
-    end
-
     @testset "mutate supports constants" begin
         df = DataFrame(x = 1:10, g =  repeat(1:2, inner = 5))
         y = 1:10

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -1,4 +1,4 @@
-@testset "mutate" verbose = true begin
+@testset "@mutate()" verbose = true begin
 
     @testset "empty mutate returns input" begin
         df = DataFrame(x = 1)

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -56,7 +56,7 @@
         )
     end
 
-    @testset " length-1 vectors are recycled" begin
+    @testset "length-1 vectors are recycled" begin
         df = DataFrame(x = 1:4)
         @test isequal(@mutate(df, y = 1)[!, :y], fill(1, 4))
         @test_throws "ArgumentError: New columns must have the same length as old columns" @mutate(df, y = 1:2)
@@ -74,7 +74,7 @@
         # or was just created
         @test isequal(
             (@mutate df begin
-                z = 1,
+                z = 1
                 z = nothing
             end
             ),

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -81,4 +81,34 @@
             df
         )
     end
+
+    @testset "mutate supports constants" begin
+        df = DataFrame(x = 1:10, g =  repeat(1:2, inner = 5))
+        y = 1:10
+        z = 1:5
+
+        @test isequal(@mutate(df, y = !!y)[!, :y], y)
+        @test isequal(
+            (@chain df begin
+                @group_by(g)
+                @mutate y = !!y
+                @ungroup
+                @pull y
+            end
+            )
+        )
+    end
+
+    @testset "mutate works on empty dataframes" begin
+        df = DataFrame()
+        res = @mutate(df)
+        @test isequal(nrow(res), 0)
+        @test isequal(ncol(res), 0)
+
+        res = @mutate(df, x = Int64[])
+        @test isequal(names(res), ["x"])
+        @test isequal(nrow(res), 0)
+        @test isequal(ncol(res), 0)
+    end
+
 end

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -108,7 +108,7 @@
         res = @mutate(df, x = Int64[])
         @test isequal(names(res), ["x"])
         @test isequal(nrow(res), 0)
-        @test isequal(ncol(res), 0)
+        @test isequal(ncol(res), 1)
     end
 
 end

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -12,50 +12,6 @@
         @test isequal(@mutate(gf, []), gf)
     end
 
-    @testset "mutations applied progressively" begin
-        df = DataFrame(x = 1)
-        @test isequal(
-            (@mutate df begin
-                    y = x + 1
-                    z = y + 1
-                end
-            ),
-            DataFrame(x = 1, y = 2, z = 3)
-        )
-
-        @test isequal(
-            (@mutate df begin
-                    x = x + 1
-                    x = x + 1
-                end
-            ),
-            DataFrame(x = 3)
-        )
-
-        @test isequal(
-            (@mutate df begin
-                    x = 2
-                    y = x
-                end
-            ),
-            DataFrame(x = 2, y = 2)
-        )
-
-        df = DataFrame(x = 1, y = 2)
-        @test isequal(
-            (@mutate df begin
-                x2 = x
-                x3 = x2 + 1
-            end
-            ),
-            (@mutate df begin
-                x2 = x + 0
-                x3 = x2 + 1
-            end
-            )
-        )
-    end
-
     @testset "length-1 vectors are recycled" begin
         df = DataFrame(x = 1:4)
         @test isequal(@mutate(df, y = 1)[!, :y], fill(1, 4))

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -1,0 +1,65 @@
+@testset "mutate" verbose = true begin
+
+    @testset "empty mutate returns input" begin
+        df = DataFrame(x = 1)
+        gf = @group_by(df, x)
+
+        @test isequal(@mutate(df), df)
+        @test isequal(@mutate(gf), gf)
+
+
+        @test isequal(@mutate(df, []), df)
+        @test isequal(@mutate(gf, []), gf)
+    end
+
+    @testset "mutations applied progressively" begin
+        df = DataFrame(x = 1)
+        @test isequal(
+            (@mutate df begin
+                    y = x + 1
+                    z = y + 1
+                end
+            ),
+            DataFrame(x = 1, y = 2, z = 3)
+        )
+
+        @test isequal(
+            (@mutate df begin
+                    x = x + 1
+                    x = x + 1
+                end
+            ),
+            DataFrame(x = 3)
+        )
+
+        @test isequal(
+            (@mutate df begin
+                    x = 2
+                    y = x
+                end
+            ),
+            DataFrame(x = 2, y = 2)
+        )
+
+        df = DataFrame(x = 1, y = 2)
+        @test isequal(
+            (@mutate df begin
+                x2 = x
+                x3 = x2 + 1
+            end
+            ),
+            (@mutate df begin
+                x2 = x + 0
+                x3 = x2 + 1
+            end
+            )
+        )
+    end
+
+    @testset " length-1 vectors are recycled" begin
+        df = DataFrame(x = 1:4)
+        @test isequal(@mutate(df, y = 1)[!, :y], fill(1, 4))
+        @test_throws "ArgumentError: New columns must have the same length as old columns" @mutate(df, y = 1:2)
+    end
+
+end

--- a/test/test_mutate.jl
+++ b/test/test_mutate.jl
@@ -44,19 +44,6 @@
         z = 1:5
 
         @test isequal(@mutate(df, y = !!y)[!, :y], y)
-        #=
-            i'm not actually sure whether this test would be one-to-one with Julia,
-            given that grouped dataframes behave differently than in R.
-        =#
-        # @test isequal(
-        #     (@chain df begin
-        #         @group_by(g)
-        #         @mutate y = !!y
-        #         @ungroup
-        #         @pull y
-        #     end
-        #     )
-        # )
     end
 
     @testset "mutate works on empty dataframes" begin


### PR DESCRIPTION
Continuing my adventure of adding unit tests for some of the core `Tidier` functionality–this PR adds some tests related to `@mutate`.

As noted in #115 , `@mutate` doesn't work progressively (eg. you can't reuse a created variable in the same call). Since this is expected behavior and just a difference between R and Julia, I went ahead and added a docstring example explaining that you _can't_ do this and to use separate calls to `@mutate` instead.

There's an outstanding question (#116) about whether `@mutate` should allow dropping columns by passing `nothing`. If the answer is "no" there, then I'll just remove that test as well. 

The rest of the tests pass and verify some of the core `@mutate` functionality and expected behavior. 🎉