### PR TITLE
possible summarize benchmark improvement

### DIFF
--- a/src/TidierData.jl
+++ b/src/TidierData.jl
@@ -338,52 +338,39 @@ macro summarize(df, exprs...)
 
     tidy_exprs = parse_tidy.(tidy_exprs; autovec=true) # use auto-vectorization inside `@summarize()`
     df_expr = quote
-        if $any_found_n || $any_found_row_number
-            if $(esc(df)) isa GroupedDataFrame
-                local df_copy = transform($(esc(df)); ungroup=false)
-            else
-                local df_copy = copy($(esc(df)))
-            end
-        else
-            local df_copy = $(esc(df)) # not a copy
+
+        local orig_df = $(esc(df))
+        local is_grouped = orig_df isa GroupedDataFrame
+        local needs_temp = $any_found_n || $any_found_row_number
+
+        local df_copy = needs_temp ? (is_grouped ? transform(orig_df; ungroup=false) : copy(orig_df)) : orig_df
+
+        if $any_found_n
+            transform!(df_copy, nrow => :TidierData_n; ungroup=false)
+        end
+        if $any_found_row_number
+            transform!(df_copy, eachindex => :TidierData_row_number; ungroup=false)
         end
 
-        if $(esc(df)) isa GroupedDataFrame
-            local col_names = groupcols($(esc(df)))
-            if $any_found_n
-                transform!(df_copy, nrow => :TidierData_n; ungroup=false)
+        local df_output
+        if is_grouped
+            local col_names = groupcols(orig_df)
+            df_output = combine(df_copy, $(tidy_exprs...); ungroup=true)
+            if $any_found_n || $any_found_row_number
+                select!(df_output, Cols(Not(r"^(TidierData_n|TidierData_row_number)$")))
             end
-            if $any_found_row_number
-                transform!(df_copy, eachindex => :TidierData_row_number; ungroup=false)
-            end
-
-            if length(col_names) == 1
-                local df_output = combine(df_copy, $(tidy_exprs...); ungroup=true)
-                if $any_found_n || $any_found_row_number
-                    select!(df_output, Cols(Not(r"^(TidierData_n|TidierData_row_number)$")))
-                end
-            else
-                local df_output = combine(df_copy, $(tidy_exprs...); ungroup=true)
-                if $any_found_n || $any_found_row_number
-                    select!(df_output, Cols(Not(r"^(TidierData_n|TidierData_row_number)$")))
-                end
+            # Re-group if there is more than one grouping column.
+            if length(col_names) > 1
                 df_output = groupby(df_output, col_names[1:end-1]; sort=false)
             end
         else
-            if $any_found_n
-                transform!(df_copy, nrow => :TidierData_n; ungroup=false)
-            end
-            if $any_found_row_number
-                transform!(df_copy, eachindex => :TidierData_row_number; ungroup=false)
-            end
-            local df_output = combine(df_copy, $(tidy_exprs...))
+            df_output = combine(df_copy, $(tidy_exprs...))
             if $any_found_n || $any_found_row_number
                 select!(df_output, Cols(Not(r"^(TidierData_n|TidierData_row_number)$")))
             end
         end
 
         log[] && @info generate_log(df_copy, df_output, "@summarize", [:newsize])
-
         df_output
     end
     if code[]


### PR DESCRIPTION
Was experimenting with the summarize macro to try to improve its benchmark a bit as the last macro not = to df.jl speed. 
This gets cuts the benchmark time in half and reduces some allocs as well. not quite as good as DF.jl but an improvement without any breaking changes .
```
# setup adapted from a bogul blog post  https://bkamins.github.io/julialang/2022/05/27/strings.html 
using Random, BenchmarkTools,  DataFrames, TidierData, PooledArrays, CategoricalArrays, InlineStrings

Random.seed!(1234);
df = transform!(DataFrame(str=[randstring() for _ in 10:10^6]),
                       :str .=>
                       [inlinestrings, ByRow(Symbol),
                        PooledArray, CategoricalArray] .=>
                       [:istr, :sym, :pstr, :cstr]);

df.A = rand(1:10, nrow(df));
df.B = rand(1:10, nrow(df));
df.C = rand(1:10, nrow(df));
categories = ["Category1", "Category2", "Category3", "Category4"];
df.CatVar = categorical(rand(categories, nrow(df)));
strings = ["String1", "String2", "String3", "String4"];
df.StrVar = rand(strings, nrow(df));
morecats = ["Category1", "Category2", "Category3", "Category4","Category5", "Category6", "Category7", "Category8"];
df.More_Cats = categorical(rand(morecats, nrow(df)));
tweleve_cats = ["Category1", "Category2", "Category3", "Category4","Category5", "Category6", "Category7", "Category8","Category9", "Category10", "Category11", "Category12"];
df.Cats_12 = categorical(rand(tweleve_cats, nrow(df)));
```
```
#OG @summarize
@benchmark  @summarize(@group_by(df, CatVar), A_mean = mean(A)) 
```
```
BenchmarkTools.Trial: 247 samples with 1 evaluation per sample.
 Range (min … max):  11.454 ms … 148.554 ms  ┊ GC (min … max):  0.00% … 90.16%
 Time  (median):     14.436 ms               ┊ GC (median):     9.01%
 Time  (mean ± σ):   20.259 ms ±  21.745 ms  ┊ GC (mean ± σ):  34.06% ± 20.50%

   █                                                            
  ▇█▆▅▅▃▃▃▂▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃ ▂
  11.5 ms         Histogram: frequency by time          117 ms <

 Memory estimate: 101.43 MiB, allocs estimate: 529.
```
```
#DF.jl reference 
@benchmark df |> (df -> groupby(df, :CatVar)) |> (df -> combine(df,:A => mean)) 
```
```
BenchmarkTools.Trial: 1865 samples with 1 evaluation per sample.
 Range (min … max):  2.229 ms …  10.298 ms  ┊ GC (min … max): 0.00% … 76.43%
 Time  (median):     2.482 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.681 ms ± 515.947 μs  ┊ GC (mean ± σ):  8.88% ± 11.80%

     ▃█▆▆▃▁                                                    
  ▁▄███████▇▃▂▂▂▄▃▄▄▄▃▂▂▃▂▂▂▁▁▂▁▁▁▁▂▂▁▂▂▂▂▂▂▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  2.23 ms         Histogram: frequency by time        4.25 ms <

 Memory estimate: 7.64 MiB, allocs estimate: 286.
```
```
# updated summarize
@benchmark  @summarize(@group_by(df, CatVar), A_mean = mean(A)) 
```
```
BenchmarkTools.Trial: 735 samples with 1 evaluation per sample.
 Range (min … max):  5.469 ms …  13.391 ms  ┊ GC (min … max):  4.81% … 52.58%
 Time  (median):     6.799 ms               ┊ GC (median):     9.00%
 Time  (mean ± σ):   6.802 ms ± 686.940 μs  ┊ GC (mean ± σ):  11.96% ±  5.91%

                     ▁▇▄▆▇▅ ▃▅ ▂ ▄█▅▆▃▄▃▆                      
  ▅▅▂▃▇▄▅▅▃▃▃▅▅▆▅▃▃▁▅██████▇██▇██████████▆▅▅▇▅▅▄▆▃▂▂▁▁▂▂▃▁▂▂▁ ▄
  5.47 ms         Histogram: frequency by time        8.22 ms <

 Memory estimate: 38.90 MiB, allocs estimate: 399.
```