### PR TITLE
possible across update to support functions w > 1 arg

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -169,6 +169,18 @@ function parse_function(lhs::Union{Symbol, Expr}, rhs::Expr; autovec::Bool=true,
   end
 end
 
+# helper: detect x -> fn(x, wt, ...) and synthesize (x, w) -> fn(x, w, ...)
+function detect_twoarg(ex)
+  if ex isa Expr && @capture(ex, x_->body_)
+    if body isa Expr && @capture(body, fn_(x_, with_Symbol, rest__))
+      return :( (x, w) -> $(fn)(x, w, $(rest...)) ), with
+    elseif body isa Expr && @capture(body, fn_(x_, with_Symbol))
+      return :( (x, w) -> $(fn)(x, w) ), with
+    end
+  end
+  return nothing, nothing
+end
+
 # Not exported
 # Note: `parse_across` currently does not support the use of numbers for selecting columns
 function parse_across(vars::Union{Expr,Symbol}, funcs::Union{Expr,Symbol})
@@ -184,25 +196,68 @@ function parse_across(vars::Union{Expr,Symbol}, funcs::Union{Expr,Symbol})
   end
 
   func_array = Union{Expr,Symbol}[] # expression containing functions
+  needs_w = Bool[]              # <— tracks whether each func wants (x,w)
+  with_sym = nothing  # mark that this function should be called as f(x, w)
 
   if funcs isa Symbol
     push!(func_array, esc(funcs)) # fixes bug where single function is used inside across
+    push!(needs_w, false)
   elseif @capture(funcs, (args__,))
     for arg in args
       if arg isa Symbol
         push!(func_array, esc(arg))
+        push!(needs_w, false)
       else
-        push!(func_array, esc(parse_tidy(arg; from_across=true))) # fixes bug with compound and anonymous functions getting wrapped in Cols()
+        twoarg, with = detect_twoarg(arg)
+        if twoarg === nothing
+          push!(func_array, esc(parse_tidy(arg; from_across=true)))
+          push!(needs_w, false)
+        else
+          with_sym === nothing && (with_sym = with)
+          push!(func_array, esc(twoarg))
+          push!(needs_w, true)
+        end
       end
     end
-  else # for compound functions like mean or anonymous functions
-    push!(func_array, esc(funcs))
+  else
+    twoarg, with = detect_twoarg(funcs)
+    if twoarg === nothing
+      push!(func_array, esc(funcs))
+      push!(needs_w, false)
+    else
+      with_sym = with
+      push!(func_array, esc(twoarg))
+      push!(needs_w, true)
+    end
   end
 
   num_funcs = length(func_array)
 
-  return :(Cols($(src...)) .=> reshape([$(func_array...)], 1, $num_funcs))
+  if with_sym === nothing
+    return :(Cols($(src...)) .=> reshape([$(func_array...)], 1, $num_funcs))
+  end
+
+  return :(AsTable(Cols($(src...), $(QuoteNode(with_sym)))) => (tbl -> begin
+    w = getproperty(tbl, $(QuoteNode(with_sym)))
+    acc = Pair{Symbol,Any}[]
+    @inbounds for nm in propertynames(tbl)
+      nm === $(QuoteNode(with_sym)) && continue
+      x = getproperty(tbl, nm)
+      eltype(x) <: Number || continue
+      $(let pushes = Expr[]
+          for (i, f) in enumerate(func_array)
+            sfx = "_" * string(i)
+            call_ex = needs_w[i] ? :($(f)(x, w)) : :($(f)(x))
+            push!(pushes, :(push!(acc, Symbol(string(nm), $sfx) => $call_ex)))
+          end
+          Expr(:block, pushes...)
+        end)
+    end
+    (; acc...)
+  end) => AsTable)
 end
+
+
 
 # Not exported
 function parse_desc(tidy_expr::Union{Expr,Symbol})


### PR DESCRIPTION
Did some experimenting to add [support](https://discourse.julialang.org/t/with-dataframes-best-practice-for-applying-function-across-columns-where-we-also-need-to-reference-in-a-second-argument-the-same-column-for-each-function-call/127747/3) for multiple function args in an across function and with relatively limited changes to `parse_across` managed to get it to work. suffix corresponds to function order in across 
```julia
julia> using TidierData, TidierFiles

julia> mtcars = read_file( "https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f23f993cd87c283ce766e7ac6b329ee7cc2e1d1/mtcars.csv");

julia> wt_mean(x,y) = x' * y / sum(y);

julia> wt_mean2(x,y,n) = x' * y / sum(y) + n;

julia> @chain mtcars begin
         @group_by(cyl)
         @summarize(across((!(wt, cyl, model)), (x -> wt_mean(x, wt))))
       end
3×10 DataFrame
 Row │ cyl    mpg_1    disp_1   hp_1      drat_1   qsec_1   vs_1      am_1      gear_1   carb_1  
     │ Int64  Float64  Float64  Float64   Float64  Float64  Float64   Float64   Float64  Float64 
─────┼───────────────────────────────────────────────────────────────────────────────────────────
   1 │     6  19.6458  185.239  121.558   3.56917  18.122   0.621219  0.378781  3.82104  3.33616
   2 │     4  25.935   110.35    83.3945  4.03126  19.3804  0.914887  0.649803  4.04725  1.57225
   3 │     8  14.8064  362.125  209.373   3.20566  16.8853  0.0       0.120381  3.24076  3.53955

julia> @chain mtcars begin
         @group_by(cyl)
         @summarize(across((!(wt, cyl, model)), (x -> wt_mean(x, wt), x -> wt_mean2(x, wt, 5), minimum)))
       end
3×28 DataFrame
 Row │ cyl    mpg_1    mpg_2    mpg_3    disp_1   disp_2   disp_3   hp_1      hp_2      hp_3   drat_1   drat_2   d ⋯
     │ Int64  Float64  Float64  Float64  Float64  Float64  Float64  Float64   Float64   Int64  Float64  Float64  F ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │     6  19.6458  24.6458     17.8  185.239  190.239    145.0  121.558   126.558     105  3.56917  8.56917    ⋯
   2 │     4  25.935   30.935      21.4  110.35   115.35      71.1   83.3945   88.3945     52  4.03126  9.03126
   3 │     8  14.8064  19.8064     10.4  362.125  367.125    275.8  209.373   214.373     150  3.20566  8.20566
                                                                                                  16 columns omitted
```