### PR TITLE
improve unnest_wider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # TidierData.jl updates
 
+## v.0.17.2 - 2025-11-
+- `@unnest_wider` now has fall back for broader types
+- add `fitquad` and `fitquadratic` to do not vectorize list
+
 ## v.0.17.1 - 2025-11-14
 - 3x speed up for `@summarize`
 - add support for multiple arg functions in `across`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierData"
 uuid = "fe2206b3-d496-4ee9-a338-6a095c4ece80"
 authors = ["Karandeep Singh"]
-version = "0.17.1"
+version = "0.17.2"
 
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"

--- a/src/TidierData.jl
+++ b/src/TidierData.jl
@@ -28,7 +28,7 @@ const code = Ref{Bool}(false) # output DataFrames.jl code?
 const log = Ref{Bool}(false) # output tidylog output?
 
 # The global do-not-vectorize "list"
-const not_vectorized = Ref{Vector{Symbol}}([:getindex, :rand, :esc, :Ref, :Set, :Cols, :collect, :(:), :∘, :lag, :lead, :ntile, :repeat, :across, :desc, :mean, :std, :var, :median, :mad, :first, :last, :minimum, :maximum, :sum, :length, :skipmissing, :quantile, :passmissing, :cumsum, :cumprod, :accumulate, :is_float, :is_integer, :is_string, :cat_rev, :cat_relevel, :cat_infreq, :cat_lump, :cat_reorder, :cat_collapse, :cat_lump_min, :cat_lump_prop, :categorical, :as_categorical, :is_categorical, :unique, :iqr, :cat_other, :cat_replace_missing, :cat_recode, :argmax, :argmin])
+const not_vectorized = Ref{Vector{Symbol}}([:getindex, :rand, :esc, :Ref, :Set, :Cols, :collect, :(:), :∘, :lag, :lead, :ntile, :repeat, :across, :desc, :mean, :std, :var, :median, :mad, :first, :last, :minimum, :maximum, :sum, :length, :skipmissing, :quantile, :passmissing, :cumsum, :cumprod, :accumulate, :is_float, :is_integer, :is_string, :cat_rev, :cat_relevel, :cat_infreq, :cat_lump, :cat_reorder, :cat_collapse, :cat_lump_min, :cat_lump_prop, :categorical, :as_categorical, :is_categorical, :unique, :iqr, :cat_other, :cat_replace_missing, :cat_recode, :argmax, :argmin, :fitquad, :fitquadratic])
 
 # The global do-not-escape "list"
 # `in`, `∈`, and `∉` should be vectorized in auto-vec but not escaped

--- a/src/nests.jl
+++ b/src/nests.jl
@@ -103,7 +103,18 @@ function unnest_wider(df::Union{DataFrame, GroupedDataFrame}, cols; names_sep::U
                 df_copy[!, new_col_name] =
                     [item isa Pair && item.first == key ? item.second : missing for item in df_copy[!, col]]
             end
+        elseif isstructtype(col_type)
+            fld_names = fieldnames(col_type)
+            for fld in fld_names
+                new_col_name = names_sep === nothing ?
+                    fld :
+                    Symbol(string(col, names_sep, fld))
 
+                df_copy[!, new_col_name] = [
+                    x === missing ? missing : getfield(x, fld)
+                    for x in df_copy[!, col]
+                ]
+            end
         else
             error("Column $col contains neither dictionaries nor arrays nor DataFrames") # COV_EXCL_LINE
         end


### PR DESCRIPTION
needed to unrestrict `@unnest_wider` with a fall back for types that were dataframes or arrays so i could unnest the fit to make this [discourse work ](https://discourse.julialang.org/t/alternative-to-map-for-grouped-dataframe/134038/6)

```
julia> @chain df begin
                  @group_by(a)
                  @summarize(model = fitquadratic(t, x))
                  @unnest_wider(model)
              end
5×9 DataFrame
 Row │ a      model_a  model_b   model_c   model_R2  model_x                          ⋯
     │ Int64  Float64  Float64   Float64   Float64   Array…                           ⋯
─────┼─────────────────────────────────────────────────────────────────────────────────
   1 │     1  2.00099  -3.01672  1.00895   0.999996  [0.0, 0.10101, 0.20202, 0.30303, ⋯
   2 │     2  1.99918  -2.99408  0.981821  0.999996  [0.0, 0.10101, 0.20202, 0.30303,
   3 │     3  1.99943  -2.99849  1.01555   0.999998  [0.0, 0.10101, 0.20202, 0.30303,
   4 │     4  2.00232  -3.02979  1.09526   0.999997  [0.0, 0.10101, 0.20202, 0.30303,
   5 │     5  2.00273  -3.02812  1.08975   0.999998  [0.0, 0.10101, 0.20202, 0.30303, ⋯
                                                                      4 columns omitted
                       
```